### PR TITLE
Explicitly mark up return type

### DIFF
--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/validation/GTSMorpherValidatorHelper.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/validation/GTSMorpherValidatorHelper.xtend
@@ -51,7 +51,7 @@ class GTSMorpherValidatorHelper {
 		]
 	}
 
-	static def doCheckIsCompleteBehaviourMapping(GTSMapping mapping, IssueAcceptor validator) {
+	static def boolean doCheckIsCompleteBehaviourMapping(GTSMapping mapping, IssueAcceptor validator) {
 		val result = new ValueHolder(true)
 
 		if (mapping.target.behaviour !== null) {


### PR DESCRIPTION
There seems to be a bug in Xtend's type inference here.