### PR TITLE
Fixed use of Pair

### DIFF
--- a/uk.ac.kcl.inf.gts_morpher.tests/src/uk/ac/kcl/inf/gts_morpher/tests/gtsfamilies/GTSFamiliesTests.xtend
+++ b/uk.ac.kcl.inf.gts_morpher.tests/src/uk/ac/kcl/inf/gts_morpher/tests/gtsfamilies/GTSFamiliesTests.xtend
@@ -53,7 +53,7 @@ class GTSFamiliesTests extends AbstractTest {
 	@Test
 	def void testGTSFamilyChoices() {
 		// TODO At some point may want to change this so it works with actual URLs rather than relying on Xtext/Ecore to pick up and search all the available ecore files
-		// Then would use �serverURI.toString� etc. below
+		// Then would use «serverURI.toString» etc. below
 		val resourceSet = createNormalResourceSet
 		val result = parseHelper.parse('''
 			export gts ServerChoice {
@@ -98,7 +98,7 @@ class GTSFamiliesTests extends AbstractTest {
 	@Test
 	def void testGTSFamilyChoicesWithRules() {
 		// TODO At some point may want to change this so it works with actual URLs rather than relying on Xtext/Ecore to pick up and search all the available ecore files
-		// Then would use �serverURI.toString� etc. below
+		// Then would use «serverURI.toString» etc. below
 		val resourceSet = createNormalResourceSet
 		val result = parseHelper.parse('''
 			export gts ServerChoice {
@@ -152,7 +152,7 @@ class GTSFamiliesTests extends AbstractTest {
 	@Test
 	def void testGTSFamilyChoicesIssues() {
 		// TODO At some point may want to change this so it works with actual URLs rather than relying on Xtext/Ecore to pick up and search all the available ecore files
-		// Then would use �serverURI.toString� etc. below
+		// Then would use «serverURI.toString» etc. below
 		val result = parseHelper.parse('''
 			export gts ServerChoice {
 				family: {

--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/composer/helpers/GloballyUniquifyNames.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/composer/helpers/GloballyUniquifyNames.xtend
@@ -38,7 +38,7 @@ class GloballyUniquifyNames implements NamingStrategy {
 		new(Map<? extends EObject, ? extends Iterable<? extends Pair<Origin, ? extends EObject>>> nameSourcesLookup,
 			UniquenessContext context, NamingStrategy naming) {
 			names = context.contextElements.map[eo | 
-				new Pair(eo, naming.weaveNames(nameSourcesLookup, eo, context))
+				(eo -> naming.weaveNames(nameSourcesLookup, eo, context))
 			].toMap([key], [value])
 			
 			// TODO: Does this always terminate? I think it does because we are always appending a locally unique appendix, so names get longer and prefixes remain unique and, as a consequence cannot clash with names in other groups

--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/composer/helpers/OriginMgr.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/composer/helpers/OriginMgr.xtend
@@ -24,5 +24,5 @@ final class OriginMgr {
 
 	static def <T extends EObject> Pair<Origin, T> rightKey(T object) { object.origKey(Origin.RIGHT) }
 
-	static def <T extends EObject> Pair<Origin, T> origKey(T object, Origin origin) { new Pair(origin, object) }
+	static def <T extends EObject> Pair<Origin, T> origKey(T object, Origin origin) { (origin -> object) }
 }

--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/composer/weavers/TGWeaver.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/composer/weavers/TGWeaver.xtend
@@ -59,7 +59,7 @@ class TGWeaver extends AbstractWeaver {
 		doWeave(EPackage, ecore.EPackage, [ ep, keyedMergeList |
 			// A bit annoying, but the only efficient way of getting around Java typing issues, short of spending ages on getting the generics right for ModelSpans.
 			val keyedMergeEPackageList = keyedMergeList.map [ kep |
-				new Pair(kep.key, kep.value as EPackage)
+				(kep.key -> kep.value as EPackage)
 			].toList
 			val mergedPackage = EcoreFactory.eINSTANCE.createEPackage => [
 				nsPrefix = keyedMergeEPackageList.weaveNameSpaces

--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/generator/GTSMorpherGenerator.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/generator/GTSMorpherGenerator.xtend
@@ -55,9 +55,9 @@ class GTSMorpherGenerator extends AbstractGenerator {
 				gtsModule.gtss.filter[gts|gts.export].map[it.gts].filter [
 					it instanceof GTSWeave || it instanceof GTSFamilyChoice
 				].map [ sel |
-					val name = (sel.eContainer as GTSSpecification).name
+					val name = (sel.eContainer as GTSSpecification).name;
 
-					new Pair(name, if (sel instanceof GTSWeave) {
+					(name -> if (sel instanceof GTSWeave) {
 						sel.doCompose(_monitor.split("Composing", 1))
 					} else if (sel instanceof GTSFamilyChoice) {
 						new Triple(sel.issues, sel.metamodel, sel.behaviour)

--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/util/GTSSpecificationHelper.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/util/GTSSpecificationHelper.xtend
@@ -134,8 +134,7 @@ class GTSSpecificationHelper {
 	static val DERIVED_GTS_RESOURCE_FACTORY = new ResourceFactoryImpl
 
 	static def derivedWovenGTS(GTSWeave weave) {
-		// FIXME: Pair doesn't have a good hash method, so no good as a key
-		weaveCache.get(new Pair(WEAVING_CONTENTS_KEY, weave), weave.eResource) [
+		weaveCache.get((WEAVING_CONTENTS_KEY -> weave), weave.eResource) [
 			val result = weave.doCompose(IProgressMonitor.NULL_IMPL)
 			
 			val issues = result.a.map[new Issue() {
@@ -188,7 +187,7 @@ class GTSSpecificationHelper {
 	}
 	
 	static def GTSInfo derivePickedGTS(GTSFamilyChoice gts) {
-		familyCache.get(new Pair(FAMILY_CONTENTS_KEY, gts),
+		familyCache.get((FAMILY_CONTENTS_KEY -> gts),
 			getSetOfResources(gts.root.metamodel, gts.root.behaviour, gts.transformers), [
 				if ((gts.transformers !== null) && (!gts.transformationSteps.steps.empty)) {
 					// Create a copy of the metamodel and behaviour (if any) from the specification ready to be transformed

--- a/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/util/MorphismCompleter.xtend
+++ b/uk.ac.kcl.inf.gts_morpher/src/uk/ac/kcl/inf/gts_morpher/util/MorphismCompleter.xtend
@@ -62,9 +62,9 @@ class MorphismCompleter {
 	 */
 	static def Pair<MorphismCompleter, Integer> getMorphismCompletions(GTSMapping mapping, boolean findAll) {
 		completionCache.get((mapping -> findAll), mapping.eResource) [
-			val completer = mapping.createMorphismCompleter
+			val completer = mapping.createMorphismCompleter;
 
-			new Pair(completer, completer.findMorphismCompletions(findAll))
+			(completer -> completer.findMorphismCompletions(findAll))
 		]
 	}
 
@@ -843,9 +843,9 @@ class MorphismCompleter {
 		if (elementsToMap.empty) {
 			var mappingVariant = new ArrayList<Pair<Rule, List<Pair<EObject, EObject>>>>
 			// Report a new morphism from tgtRule to srcRule with the specific mappings found
-			mappingVariant.add(new Pair(srcRule, behaviourMapping.filter [ src, tgt |
+			mappingVariant.add((srcRule -> behaviourMapping.filter [ src, tgt |
 				srcRule.eAllContents.exists[it === src]
-			].entrySet.map[e|new Pair<EObject, EObject>(e.key, e.value)].toList))
+			].entrySet.map[e|(e.key -> e.value)].toList))
 
 			return new Morphism(mappingVariant)
 		}


### PR DESCRIPTION
This closes #41 

Checking the [code of `Pair`, in Xtext sources](https://github.com/eclipse/xtext-lib/blob/master/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Pair.java), it turns out that it actually does provide appropriate `equals()` and `hashCode()` implementations. I have, however, standardises to the `->` notation.